### PR TITLE
remove errant character in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
       "@emotion/babel-preset-css-prop"
     ]
   },
-  "devDep{endencies": {
+  "devDependencies": {
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^8.0.4",
     "all-contributors-cli": "^6.8.0"


### PR DESCRIPTION
Remove mistyped `{` that fixes test errors because of missing devDependencies.